### PR TITLE
Fix: accept BCJ stream sizes of 2 GiB and larger

### DIFF
--- a/src/ext/_bcjmodule.c
+++ b/src/ext/_bcjmodule.c
@@ -296,9 +296,9 @@ BCJEncoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 BCJDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:BCJDecoder.__init__", kwlist,
+                                     "K:BCJDecoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -312,7 +312,11 @@ BCJDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = x86;
     self->readAhead = 5;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 
@@ -392,9 +396,9 @@ ARMEncoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 ARMDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:ARMDecoder.__init__", kwlist,
+                                     "K:ARMDecoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -408,7 +412,11 @@ ARMDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = arm;
     self->readAhead = 4;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 
@@ -488,9 +496,9 @@ ARMTEncoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 ARMTDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:ARMTDecoder.__init__", kwlist,
+                                     "K:ARMTDecoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -504,7 +512,11 @@ ARMTDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = armt;
     self->readAhead = 4;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 
@@ -584,9 +596,9 @@ PPCEncoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 PPCDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:PPCDecoder.__init__", kwlist,
+                                     "K:PPCDecoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -600,7 +612,11 @@ PPCDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = ppc;
     self->readAhead = 4;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 
@@ -680,9 +696,9 @@ IA64Encoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 IA64Decoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:IA64Decoder.__init__", kwlist,
+                                     "K:IA64Decoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -696,7 +712,11 @@ IA64Decoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = ia64;
     self->readAhead = 4;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 
@@ -777,9 +797,9 @@ SparcEncoder_flush(BCJFilter *self, PyObject *args, PyObject *kwargs) {
 static int
 SparcDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     static char *kwlist[] = {"size", NULL};
-    int size;
+    unsigned long long size;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "i:SparcDecoder.__init__", kwlist,
+                                     "K:SparcDecoder.__init__", kwlist,
                                      &size)) {
         return -1;
     }
@@ -793,7 +813,11 @@ SparcDecoder_init(BCJFilter *self, PyObject *args, PyObject *kwargs) {
     self->method = sparc_arch;
     self->readAhead = 4;
     self->isEncoder = False;
-    self->remiaining = size;
+    self->remiaining = (size_t)size;
+    if ((unsigned long long)self->remiaining != size) {
+        PyErr_SetString(PyExc_OverflowError, "size is too large for size_t");
+        goto error;
+    }
     self->state = 0;
     return 0;
 


### PR DESCRIPTION
### Problem

`BCJDecoder(size)` (and the ARM/ARMT/PPC/SPARC/IA64 decoders) raise `OverflowError` when `size >= 2**31`:

- on 64-bit Linux/macOS: `OverflowError: signed integer is greater than maximum`
- on Windows: `OverflowError: Python int too large to convert to C long`

This makes it impossible to decode a 7z **solid block larger than 2 GiB** through py7zr. Real-world archives produced by 7-Zip-zstd (mcmilk fork) with `ZStandard + BCJ(x86)` routinely have multi-GiB solid folders, so py7zr fails on them with this error from `compressor.py`:

```
File ".../py7zr/compressor.py", line 467, in __init__
    self.decoder = bcj.BCJDecoder(size)
OverflowError: signed integer is greater than maximum
```

### Root cause

The six `*Decoder_init` functions in `src/ext/_bcjmodule.c` parse the `size` argument with the `"i"` format code into a C `int`, which is 32-bit and overflows at `2**31`. The value is then stored in `size_t remiaining`, and the converters already take `SizeT size` (see `Bra.h`), so the **only** place the value is truncated is argument parsing.

### Fix

Parse `size` as `unsigned long long` with the `"K"` format code in all six decoder initializers (x86/ARM/ARMT/PPC/SPARC/IA64). No other change is needed — storage (`size_t`) and the converters (`SizeT`) are already 64-bit.

(Alternative: `Py_ssize_t` + `"n"` would also work and matches CPython's size convention; happy to switch if preferred.)

### Validation

Built the patched extension with MSVC (CPython 3.13, Windows x64) and decoded a real 23.7 GiB `ZStandard + BCJ(x86)` 7z archive with six solid blocks of 3.4–4.3 GiB each, via py7zr. All 5156 files passed py7zr's per-file CRC32 check, including blocks that previously raised `OverflowError`. The x86 `ip` remains `UInt32`, matching the upstream 7-Zip x86 filter (wraps mod 2**32); solid blocks are < 4 GiB so this is unaffected.
